### PR TITLE
Adding pusher type field

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -23,6 +23,7 @@ firebase functions:config:set "$(cat credentials-file.json)"
   "token":...
   "systemName":...
   "systemVersion":...
+  "pusherType": "FCM" | "APNS"
 }
 ```
 * `POST /examplePush` - the endpoint realizing assumed push endpoint
@@ -34,8 +35,9 @@ To be used with this project the tested push solution should expose following en
 that accepts following input format:
 ```
 {
-  "deviceToken":...
-  "body":...
+  "deviceToken":...,
+  "body":...,
+  "pusherType":....
 }
 ```
 

--- a/functions/src/register.ts
+++ b/functions/src/register.ts
@@ -2,6 +2,7 @@ interface Device {
   token: string;
   systemVersion: string;
   systemName: string;
+  pusherType: string;
 }
 
 export class PinDoesntExistError extends Error {
@@ -18,10 +19,18 @@ const assertPresent = (fieldName : string, val : any) => {
   }
 }
 
+const assertInSet = (name : string, val : string, acceptedValues: Set<string>) => {
+  if (!acceptedValues.has(val)) {
+    throw new Error(`${val} is not accepted as ${name}. Should be one of ${acceptedValues}`) 
+  }
+};
+
 const validateDevice = (device : Device) => {
   assertPresent("token", device.token);
   assertPresent("systemVersion", device.systemVersion);
   assertPresent("systemName", device.systemName);
+  assertPresent("pusherType", device.pusherType);
+  assertInSet("pusherType", device.pusherType, new Set(["FCM", "APNS"]));
 };
 
 export const register = (db : FirebaseFirestore.Firestore) => {


### PR DESCRIPTION
 * the pusher type field has to be provided when registering device
 * pusher type field has to be passed to push endpoint (as its hard to retrieve it without knowing the actual PIN number)

closes #22 